### PR TITLE
Fix programming language for quantum katas project

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 **C++**
 - [XACC VQE](https://github.com/ORNL-QCI/xacc-vqe) - Distributed Variational Quantum Eigensolver built on [XACC](https://github.com/ORNL-QCI/xacc) for solving electronic structure problems.
 
-**C#**
+**Q#**
 - [Quantum Katas](https://github.com/Microsoft/QuantumKatas) -  Programming exercises for learning Q# and quantum computing.
 
 


### PR DESCRIPTION
Quantum katas are actually in Q#, C# is just a wrapper language and is not used to express the algorithms.