### PR TITLE
Add Quditto to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [Qibo](https://github.com/qiboteam/qibo) - Framework for quantum simulation with hardware acceleration using just-in-time compilation.
 - [QTop](https://github.com/jacobmarks/QTop) - Simulation and visualization of topological quantum computers.
 - [quantum-computing](https://github.com/QuantumSystems/quantum-computing) - Functionally complete simulator for universal quantum computing in Python
+- [Quditto](https://github.com/Networks-it-uc3m/Quditto) - QKD Network emulator that automatically deploys distributed, ETSI GS QKD 014–compliant QKD networks.
 - [QuForge](https://github.com/tiago939/QuForge) - Python package for qudit simulation.
 - [quimb](https://github.com/jcmgray/quimb) - Easy but fast python library for quantum information and many-body calculations, including with tensor networks.
 - [Quintuple](https://github.com/corbett/QuantumComputing) - Simulating the 5-qubit processor of the [IBM Quantum Experience](https://quantumexperience.ng.bluemix.net/qx/experience).


### PR DESCRIPTION
The Quditto emulation platform has been added. It is an open-source project that allows the automatic deployment of emulated QKD networks over any Python-capable hardware. The nodes of the emulated network implement the ETSI 014 API, making the interaction between users and said nodes the same as between users and real QKD devices.