### PR TITLE
Add qqa under Quantum annealing > Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [minorminer](https://github.com/dwavesystems/minorminer) - Heuristic tool for minor graph embedding.
 - [penaltymodel](https://github.com/dwavesystems/penaltymodel) - Utilities and interfaces for using penalty models.
 - [QMASM](https://github.com/lanl/qmasm/) - Quantum macro assembler for D-Wave systems
+- [qqa](https://github.com/Yuma-Ichikawa/QQA4CO) - GPU-parallel Quasi-Quantum Annealing toolkit for QUBO and Ising combinatorial optimisation, with PI-GNN / CPRA neural backends and a Simulated Annealing baseline, all under a single PyTorch API.
 - [qubo-nn](https://github.com/instance01/qubo-nn/) - Classifying, auto-encoding and reverse-engineering QUBO matrices. Also includes 20 problem formulations.
 - [qubovert](https://github.com/jtiosue/qubovert) - Formulating and simulated annealing of Ising, QUBO, and higher order problems with constraints.
 


### PR DESCRIPTION
This PR adds [qqa](https://github.com/Yuma-Ichikawa/QQA4CO) to the **Quantum annealing > Python** section, inserted alphabetically between `QMASM` and `qubo-nn`.

### About the project
`qqa` is an open-source PyTorch toolkit that implements Quasi-Quantum Annealing (QQA, ICLR 2025) for combinatorial optimisation. It runs entirely on classical hardware (CPU / CUDA / MPS) but uses a quantum-annealing-inspired update rule, so it sits naturally next to D-Wave's `dwave_neal`, `qubo-nn`, and `qubovert`.

Highlights:
- GPU-parallel **PQQA** solver (single-GPU annealing of many replicas).
- **PI-GNN / CRA-PI-GNN / CPRA** unsupervised graph-neural-network backends as drop-in alternatives.
- **Simulated Annealing** baseline with a QUBO-aware Glauber fast path and a generic single-spin fallback.
- 17-class problem catalogue (MIS, MaxCut, Coloring, 3D Edwards-Anderson, SK, binary perceptron, Hopfield memory, ...).
- CLI (`qqa solve`, `qqa bench`, `qqa gui`), interactive Streamlit dashboard, MkDocs Material documentation, and a Colab quickstart.
- Released on PyPI as `qqa`, BSD-3-Clause-Clear, CI / lint / format / coverage / mkdocs all green, Trusted Publishing wired up.
- Software DOI: [10.5281/zenodo.19648231](https://doi.org/10.5281/zenodo.19648231) (Zenodo).

### Contributing-guideline checklist
- [x] Open-source project (BSD-3-Clause-Clear, code on GitHub).
- [x] Listed under the correct category (`Quantum annealing` > `Python`).
- [x] Inserted in alphabetical order between `QMASM` and `qubo-nn`.
- [x] Format `[Name](link) - Description.` with capital start and full stop.
- [x] Does not start the description with `A` / `An`.
- [x] One-line entry, no duplicates of existing items.
- [x] Spelling and grammar checked.