### PR TITLE
Add EMRG to Quantum compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 **Python**
 - [Arline Benchmarks](https://github.com/ArlineQ/arline_benchmarks) - Automated benchmarking platform for quantum compilers, quantum hardware and quantum algorithms.
 - [BQSKit](https://github.com/BQSKit) - Berkeley Quantum Synthesis Toolkit is an optimizing quantum compiler and related tool-set.
+- [EMRG](https://github.com/FedorShind/EMRG) - Quantum error mitigation toolkit with ZNE, PEC, and CDR support.
 - [Mitiq](https://github.com/unitaryfoundation/mitiq) - Cross-platform, quantum error mitigation toolkit and compiler from [Unitary Foundation](https://unitary.foundation/).
 - [MQT IonShuttler](https://github.com/cda-tum/mqt-ion-shuttler) - Exact and heuristic scheduling to manage ion movement within trapped-ion hardware.
 - [MQT Predictor](https://github.com/cda-tum/mqt-predictor) - RL-based compiler optimization. ML-based device selection. Available via the [`mqt.predictor`](https://pypi.org/p/mqt.predictor) Python package.


### PR DESCRIPTION
Error mitigation toolkit for NISQ circuits -- supports ZNE, PEC, and CDR.

Placed under Quantum compilers / Python next to Mitiq.

https://github.com/FedorShind/EMRG