### PR TITLE
Add gradpulse to quantum control tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 
 **Python**
 - [C3](https://github.com/q-optimize/c3) - Open-loop, closed-loop and automated Control, Calibration and Characterization of quantum devices.
+- [gradpulse](https://github.com/PureStateLabs/gradpulse) - Differentiable, multi-solver-validated pulse optimizer for open-system superconducting-gate fidelities.
 - [Krotov](https://github.com/qucontrol/krotov) - Python implementation of Krotov's method for quantum optimal control.
 - [Qibo](https://github.com/qiboteam/qibo) - Qibo provides a platform agnostic quantum hardware control module with drivers for multiple instruments.
 - [Quanlse](https://github.com/baidu/Quanlse) - Quanlse provides quantum control solutions via a cloud SDK, developed by [Baidu Quantum](https://research.baidu.com/Research_Areas/index-view?id=75).


### PR DESCRIPTION
Adds gradpulse to the list.

- Project: gradpulse, an open-source (MIT) differentiable, multi-solver-validated pulse optimizer for open-system superconducting-gate fidelities.
- Repo: https://github.com/PureStateLabs/gradpulse
- Category: placed under [the category where qutip-qtrl / c3-toolset live], Python subheading.

Checklist:
- [x] Searched the list and open PRs for duplicates.
- [x] Project is open-source.
- [x] Listed under the correct category and Python subheading.
- [x] Alphabetical order preserved.
- [x] Format: [Name](link) - Description ending with a full stop, not starting with A/An.
- [x] Spelling and grammar checked.