### PR TITLE
Add CleitonForge — neutral cross-backend quantum benchmarking (Rust + Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 
 **Python**
 - [Arline Benchmarks](https://github.com/ArlineQ/arline_benchmarks) - Automated benchmarking platform for quantum compilers, quantum hardware and quantum algorithms.
+- [CleitonForge](https://github.com/cleitonaugusto/CleitonForge) - Neutral cross-backend benchmarking layer for quantum circuit simulators (Rust + Python). Discovered a silent Rz gate sign convention disagreement that produces zero QAOA fidelity across backends. Includes a convention normalization transpiler. Preprint: [10.5281/zenodo.21210972](https://doi.org/10.5281/zenodo.21210972).
 - [BQSKit](https://github.com/BQSKit) - Berkeley Quantum Synthesis Toolkit is an optimizing quantum compiler and related tool-set.
 - [EMRG](https://github.com/FedorShind/EMRG) - Quantum error mitigation toolkit with ZNE, PEC, and CDR support.
 - [Mitiq](https://github.com/unitaryfoundation/mitiq) - Cross-platform, quantum error mitigation toolkit and compiler from [Unitary Foundation](https://unitary.foundation/).


### PR DESCRIPTION
## CleitonForge

**Link:** https://github.com/cleitonaugusto/CleitonForge

**Description:** Neutral cross-backend benchmarking layer for quantum circuit simulators, written in Rust with Python bindings. Routes identical circuits through multiple backends via a canonical intermediate representation and compares statevector fidelity.

**Notable finding:** Discovered a silent Rz gate sign convention disagreement in quantrs2-core that produces zero cross-backend fidelity on QAOA/VQE circuits — while being completely invisible to Quantum Volume benchmarks. Published as a preprint: [DOI 10.5281/zenodo.21210972](https://doi.org/10.5281/zenodo.21210972).

**Features:**
- Multi-backend benchmarking (native statevector, quantrs2, roqoqo, q1tsim)
- Convention normalization transpiler (`cforge.normalize(circuit)`)
- QASM 2/3 parser
- Python bindings via PyO3
- Available on PyPI: `pip install cleitonforge`
- Apache 2.0

**Category:** Benchmarking (Python + Rust)