### PR TITLE
hybridlane

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [Cirq](https://github.com/quantumlib/Cirq) - Framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.
 - [CUDA-Q](https://github.com/NVIDIA/cuda-quantum) - Platform for accelerated quantum-classical applications on GPUs, CPUs and QPUs.
 - [Forest](https://github.com/rigetticomputing/pyquil) - [Rigetti](https://www.rigetti.com/)'s software library for writing, simulating, compiling and executing quantum programs.
+- [hybridlane](https://github.com/pnnl/hybridlane) - Full-stack library for mixed-variable (CV-DV) quantum programming across simulators and hardware within PennyLane.
 - [Ket](https://quantumket.org) - Embedded programming language that introduces the ease of Python to quantum programming.
 - [Ocean](https://github.com/dwavesystems/dwave-ocean-sdk) - [D-Wave System](https://www.dwavesys.com/home)'s suite of tools for solving hard problems with quantum computers.
 - [OpenQL](https://github.com/QE-Lab/OpenQL) - Compiler framework with algorithm libraries, optimizer, scheduler, QEC, mapping, micro-code generator.


### PR DESCRIPTION
Hello :)

This PR adds [hybridlane](https://github.com/pnnl/hybridlane), a relatively new library for mixed qubit-boson programming. It's similar to (and inspired by) Bosonic Qiskit, which is on the list, but hybridlane also facilitates compilation and execution across simulators and hardware. It's under active development (I'm the maintainer, hi!) and is open source, and I was hoping to get it on this list.

[arXiv paper](https://arxiv.org/abs/2603.10919) for reference