### PR TITLE
Add autoq-qec to Quantum error correction / Python 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<img width="1360" height="768" alt="image" src="https://github.com/user-attachments/assets/e1fda49e-a5de-4df4-bc7f-bbf3e2918831" />
 <p align="center"><img src="hopf_fibration.png" alt="bDialog" height="300px"></p>
 
 # Open-Source Quantum Software Projects
@@ -353,6 +354,7 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 - [CodingTheory](https://github.com/esabo/CodingTheory) - Julia package for constructing and analyzing classical and quantum error-correcting codes.
 
 **Python**
+- [autoq-qec](https://github.com/Ronaldoengenhariadacomputacao/autoq-qec) - Multi-code fault-tolerant QEC resource estimator for arbitrary Qiskit circuits (Surface Code, Floquet Code, Bacon-Shor, Steane).
 - [Chromobius](https://github.com/quantumlib/chromobius) - Python implementation of a "mobius decoder" for color codes used in quantum error correction.
 - [MQT QECC](https://github.com/cda-tum/mqt-qecc) - Synthesis of fault-tolerant circuits. Decoders. Automatic Application of error correcting codes. Available via the [`mqt.qecc`](https://pypi.org/p/mqt.qecc) Python package.
 - [PyMatching](https://github.com/oscarhiggott/PyMatching) - Python package for decoding quantum error correcting codes with minimum-weight perfect matching.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-<img width="1360" height="768" alt="image" src="https://github.com/user-attachments/assets/e1fda49e-a5de-4df4-bc7f-bbf3e2918831" />
-<p align="center"><img src="hopf_fibration.png" alt="bDialog" height="300px"></p>
-
 # Open-Source Quantum Software Projects
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/qosfoundation?style=social)](https://twitter.com/qosfoundation)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<p align="center"><img src="hopf_fibration.png" alt="bDialog" height="300px"></p>
+
 # Open-Source Quantum Software Projects
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/qosfoundation?style=social)](https://twitter.com/qosfoundation)


### PR DESCRIPTION
 Add autoq-qec to Quantum error correction / Python 

**autoq-qec** is a multi-code QEC resource estimator for Qiskit circuits, supporting Surface Code, Floquet Code, Bacon-Shor, and Steane codes. It ranks hardware/code combinations by physical qubit count, fidelity, and execution time.

**Credentials:**
- Listed in the [Qiskit Ecosystem](https://qisk.it/e-5c47e416) (official submission process, reviewed by IBM maintainers)
- Validated on real IBM hardware (ibm_fez, 156 qubits) with published dataset — DOI: [10.5281/zenodo.21571465](https://doi.org/10.5281/zenodo.21571465)
- Software DOI: [10.5281/zenodo.21560570](https://doi.org/10.5281/zenodo.21560570)
- [PyPI](https://pypi.org/project/autoq-qec/) | MIT License | CI passing | 142 tests