### PR TITLE
Fix CleitonForge entry: shorten it and restore alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,8 @@ For a curated list of learning resources please check out [desireevl's repo](htt
 
 **Python**
 - [Arline Benchmarks](https://github.com/ArlineQ/arline_benchmarks) - Automated benchmarking platform for quantum compilers, quantum hardware and quantum algorithms.
-- [CleitonForge](https://github.com/cleitonaugusto/CleitonForge) - Neutral cross-backend benchmarking layer for quantum circuit simulators (Rust + Python). Discovered a silent Rz gate sign convention disagreement that produces zero QAOA fidelity across backends. Includes a convention normalization transpiler. Preprint: [10.5281/zenodo.21210972](https://doi.org/10.5281/zenodo.21210972).
 - [BQSKit](https://github.com/BQSKit) - Berkeley Quantum Synthesis Toolkit is an optimizing quantum compiler and related tool-set.
+- [CleitonForge](https://github.com/cleitonaugusto/CleitonForge) - Differential fuzzer for quantum compilers and simulators (Rust + Python), with a shrinker and an exact-operator oracle.
 - [EMRG](https://github.com/FedorShind/EMRG) - Quantum error mitigation toolkit with ZNE, PEC, and CDR support.
 - [Mitiq](https://github.com/unitaryfoundation/mitiq) - Cross-platform, quantum error mitigation toolkit and compiler from [Unitary Foundation](https://unitary.foundation/).
 - [MQT IonShuttler](https://github.com/cda-tum/mqt-ion-shuttler) - Exact and heuristic scheduling to manage ion movement within trapped-ion hardware.


### PR DESCRIPTION
Follow-up to #175, fixing two things I got wrong in it.

The entry was 388 characters. The median in that section is 140 and the next
longest is 206, so mine was well outside the house style and the guidelines ask
for a very short summary on one line. It is now 186.

It also sat between Arline Benchmarks and BQSKit instead of after BQSKit, which
breaks the alphabetical ordering the guidelines ask for. Moved.

While shortening it I also dropped two things. The description led with "neutral
cross-backend benchmarking layer", which is not what the project is any more,
and it linked a Zenodo record as "Preprint" when that record is software, not a
preprint. That label was my mistake.

Sorry for the churn so soon after you merged the original, and thanks for taking
it in the first place.